### PR TITLE
Oreo 98 interactive choice for dynamic ansible inventory

### DIFF
--- a/Jenkinsfiles/Consul_db_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_db_agent_jenkinsfile
@@ -1,0 +1,35 @@
+pipeline {
+    agent any
+
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('aws_access_key_id')
+        AWS_SECRET_ACCESS_KEY = credentials('aws_secret_access_key')
+        AWS_DEFAULT_REGION    = 'eu-central-1'
+        env_name= 'dev-01'
+    }
+    parameters {
+         choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment')
+   }
+    stages {
+
+        stage('Configure Consul db agent as service') {
+            steps {
+                withCredentials([
+                    sshUserPrivateKey(
+                        credentialsId: 'oreo_ssh',
+                        keyFileVariable: 'SSH_KEY',
+                        usernameVariable: 'SSH_USER'
+                    )
+                ]) {
+                    dir('ansible') {
+                        sh '''
+                        ansible-inventory -i aws_ec2.yml --graph
+                        ansible-playbook -i aws_ec2.yml consul_db_agent.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=$ENV_NAME
+                        '''
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Jenkinsfiles/Consul_db_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_db_agent_jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         AWS_ACCESS_KEY_ID     = credentials('aws_access_key_id')
         AWS_SECRET_ACCESS_KEY = credentials('aws_secret_access_key')
         AWS_DEFAULT_REGION    = 'eu-central-1'
-        env_name= 'dev-01'
+        
     }
     parameters {
          choice(name: 'ENV_NAME', choices: ['stage-01','dev-01'], description: 'Select environment')

--- a/Jenkinsfiles/Consul_db_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_db_agent_jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         env_name= 'dev-01'
     }
     parameters {
-         choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment')
+         choice(name: 'ENV_NAME', choices: ['stage-01','dev-01'], description: 'Select environment')
    }
     stages {
 

--- a/Jenkinsfiles/Consul_jenkinsfile
+++ b/Jenkinsfiles/Consul_jenkinsfile
@@ -28,7 +28,7 @@ parameters {
                         sh '''
                         export ANSIBLE_HOST_KEY_CHECKING=False
                         ansible-inventory -i aws_ec2.yml --graph
-                        ansible-playbook -i aws_ec2.yml consul_server.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=${params.ENV_NAME}
+                        ansible-playbook -i aws_ec2.yml consul_server.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=$ENV_NAME
                         '''
                     }
                 }

--- a/Jenkinsfiles/Consul_jenkinsfile
+++ b/Jenkinsfiles/Consul_jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
 
-properties([
+options ([
     parameters([
         choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment'),
       ])

--- a/Jenkinsfiles/Consul_jenkinsfile
+++ b/Jenkinsfiles/Consul_jenkinsfile
@@ -1,0 +1,41 @@
+pipeline {
+    agent any
+
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('aws_access_key_id')
+        AWS_SECRET_ACCESS_KEY = credentials('aws_secret_access_key')
+        AWS_DEFAULT_REGION    = 'eu-central-1'
+    }
+
+
+properties([
+    parameters([
+        choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment'),
+      ])
+])
+
+
+    stages {
+
+        stage('Configure Consul server as service') {
+            steps {
+                withCredentials([
+                    sshUserPrivateKey(
+                        credentialsId: 'oreo_ssh',
+                        keyFileVariable: 'SSH_KEY',
+                        usernameVariable: 'SSH_USER'
+                    )
+                ]) {
+                    dir('ansible') {
+                        sh '''
+                        export ANSIBLE_HOST_KEY_CHECKING=False
+                        ansible-inventory -i aws_ec2.yml --graph
+                        ansible-playbook -i aws_ec2.yml consul_server.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=${params.ENV_NAME}
+                        '''
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Jenkinsfiles/Consul_jenkinsfile
+++ b/Jenkinsfiles/Consul_jenkinsfile
@@ -8,11 +8,9 @@ pipeline {
     }
 
 
-options ([
-    parameters([
-        choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment'),
-      ])
-])
+parameters {
+    choice(name: 'ENV_NAME', choices: ['dev-01', 'stage-01'], description: 'Select environment')
+}
 
 
     stages {

--- a/Jenkinsfiles/Consul_lb_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_lb_agent_jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                     dir('ansible') {
                         sh '''
                         ansible-inventory -i aws_ec2.yml --graph
-                        ansible-playbook -i aws_ec2.yml consul_lb_agent.yml -u ubuntu --private-key "$SSH_KEY"
+                        ansible-playbook -i aws_ec2.yml consul_lb_agent.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=$ENV_NAME
                         '''
                     }
                 }

--- a/Jenkinsfiles/Consul_lb_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_lb_agent_jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+    agent any
+
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('aws_access_key_id')
+        AWS_SECRET_ACCESS_KEY = credentials('aws_secret_access_key')
+        AWS_DEFAULT_REGION    = 'eu-central-1'
+        }
+
+ parameters {
+         choice(name: 'ENV_NAME', choices: ['stage-01','dev-01'], description: 'Select environment')
+   }
+
+
+    stages {
+
+        stage('Configure Consul lb agent as service') {
+            steps {
+                withCredentials([
+                    sshUserPrivateKey(
+                        credentialsId: 'oreo_ssh',
+                        keyFileVariable: 'SSH_KEY',
+                        usernameVariable: 'SSH_USER'
+                    )
+                ]) {
+                    dir('ansible') {
+                        sh '''
+                        ansible-inventory -i aws_ec2.yml --graph
+                        ansible-playbook -i aws_ec2.yml consul_lb_agent.yml -u ubuntu --private-key "$SSH_KEY"
+                        '''
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Jenkinsfiles/Consul_web_agent_jenkinsfile
+++ b/Jenkinsfiles/Consul_web_agent_jenkinsfile
@@ -1,0 +1,34 @@
+pipeline {
+    agent any
+
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('aws_access_key_id')
+        AWS_SECRET_ACCESS_KEY = credentials('aws_secret_access_key')
+        AWS_DEFAULT_REGION    = 'eu-central-1'
+    }
+ parameters {
+         choice(name: 'ENV_NAME', choices: ['stage-01','dev-01'], description: 'Select environment')
+   }
+    stages {
+
+        stage('Configure Consul web agent as service') {
+            steps {
+                withCredentials([
+                    sshUserPrivateKey(
+                        credentialsId: 'oreo_ssh',
+                        keyFileVariable: 'SSH_KEY',
+                        usernameVariable: 'SSH_USER'
+                    )
+                ]) {
+                    dir('ansible') {
+                        sh '''
+                        ansible-inventory -i aws_ec2.yml --graph
+                        ansible-playbook -i aws_ec2.yml consul_web_agent.yml -u ubuntu --private-key "$SSH_KEY" -e env_name=$ENV_NAME
+                        '''
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/ansible/consul_db_agent.yml
+++ b/ansible/consul_db_agent.yml
@@ -1,5 +1,5 @@
 - name: Setup Consul
-  hosts: _dev_01_database_instance # or _stage_consul_instance
+  hosts: "_{{ env_name | replace('-', '_') }}_database_instance"
   become: yes
   gather_facts: yes
   vars:

--- a/ansible/consul_lb_agent.yml
+++ b/ansible/consul_lb_agent.yml
@@ -1,5 +1,5 @@
 - name: Setup Consul
-  hosts: _dev_01_nginx_load_balancer # or _stage_consul_instance
+  hosts: "_{{ env_name | replace('-', '_') }}_nginx_load_balancer"
   become: yes
   gather_facts: yes
   vars:

--- a/ansible/consul_server.yml
+++ b/ansible/consul_server.yml
@@ -1,5 +1,5 @@
 - name: Setup Consul
-  hosts: _dev_01_consul_instance # or _stage_consul_instance
+  hosts: "_{{ env_name | replace('-', '_') }}_consul_instance"
   become: yes
   gather_facts: yes
   vars:

--- a/ansible/consul_web_agent.yml
+++ b/ansible/consul_web_agent.yml
@@ -1,5 +1,5 @@
 - name: Setup Consul
-  hosts: _dev_01_webapp_asg_instance # or _stage_consul_instance
+  hosts: "_{{ env_name | replace('-', '_') }}_webapp_asg_instance"
   become: yes
   gather_facts: yes
   vars:
@@ -7,6 +7,7 @@
     consul_group: consul
     consul_data_dir: /opt/consul/data
     env_name: "{{ lookup('env','env_name') }}"
+    webapp_group: "_{{ env_name | replace('-', '_') }}_webapp_asg_instance"
 
   tasks:
     - name: Ensure consul user exists
@@ -32,7 +33,7 @@
         group: '{{ consul_group }}'
         mode: '0644'
       vars:
-        node_index: "{{ groups['_dev_01_webapp_asg_instance'].index(inventory_hostname) + 1 }}"
+        node_index: '{{ groups[webapp_group].index(inventory_hostname) + 1 }}'
 
     - name: Deploy Consul systemd service
       template:

--- a/ansible/templates/consul_lb_agent.service.j2
+++ b/ansible/templates/consul_lb_agent.service.j2
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 User=consul
 Group=consul
-ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d
+ExecStart=/usr/bin/consul agent -config-file=/etc/consul.d/lb.hcl
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
[JIra ticket](https://oreoio.atlassian.net/browse/OREO-98)
Playbook can deploy consul as a server can be run on different environment without hardcoding group name
Playbook can deploy consul agent on db/web/lb instances on different environment without hardcoding group name
Validated on stage-01 environment